### PR TITLE
feat(sveltekit): Add windows-x64-baseline target

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -38,7 +38,7 @@ Run the executable.
 
 - `out`: The output directory for the built binary (default: `dist`).
 - `binaryName`: The name of the executable (default: `app`).
-- `target`: The target platform for the binary (default to your current platform). Available targets: `linux-x64`, `macos-arm64`, `windows-x64`, `darwin-x64`, `darwin-arm64`, `linux-x64-musl`, `linux-arm64-musl`.
+- `target`: The target platform for the binary (default to your current platform). Available targets: `linux-x64`, `linux-x64-baseline`, `macos-arm64`, `windows-x64`, `windows-x64-baseline`, `darwin-x64`, `darwin-arm64`, `linux-x64-musl`, `linux-arm64-musl`.
 - `volume`: The volume mount point for the binary (no volume mount by default). Useful for persistent storage for self-hosting, usually `/data`.
 - `external`: The external dependencies to exclude from bundling (comma-separated string or array).
 

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jesterkit/exe-nuxt",
   "module": "dist/index.ts",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "EXE is a tool for TanStack to build a standalone executable with full stack features such as SSR, API routes, server hooks....",
   "author": "Hugo Duprez",
   "license": "MIT",

--- a/packages/nuxt/src/constants/const.ts
+++ b/packages/nuxt/src/constants/const.ts
@@ -6,6 +6,7 @@ export const TARGETS_MAP: Record<NonNullable<CLIArgs["target"]>, string> = {
 	"linux-x64-baseline": "bun-linux-x64-baseline",
 	"macos-arm64": "bun-macos-arm64",
 	"windows-x64": "bun-windows-x64",
+	"windows-x64-baseline": "bun-windows-x64-baseline",
 	"darwin-x64": "bun-darwin-x64",
 	"darwin-arm64": "bun-darwin-arm64",
 	"linux-x64-musl": "bun-linux-x64-musl",

--- a/packages/nuxt/src/types/CLIArgs.d.ts
+++ b/packages/nuxt/src/types/CLIArgs.d.ts
@@ -3,6 +3,7 @@ type Target =
 	| "linux-x64-baseline"
 	| "macos-arm64"
 	| "windows-x64"
+	| "windows-x64-baseline"
 	| "darwin-x64"
 	| "darwin-arm64"
 	| "linux-x64-musl"

--- a/packages/nuxt/src/utils/validation.ts
+++ b/packages/nuxt/src/utils/validation.ts
@@ -2,8 +2,10 @@ import type { CLIArgs } from "../types/CLIArgs";
 
 export const VALID_TARGETS = [
 	"linux-x64",
+	"linux-x64-baseline",
 	"macos-arm64", 
 	"windows-x64",
+	"windows-x64-baseline",
 	"darwin-x64",
 	"darwin-arm64",
 	"linux-x64-musl",

--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -40,7 +40,7 @@ Run the executable
 - `out`: The output directory for the built binary (default: `dist`).
 - `binaryName`: The name of the executable (default: `app`).
 - `embedStatic`: Whether to embed static assets in the binary (default: `true`).
-- `target`: The target platform for the binary (default to your current platform). Available targets: `linux-x64`, `macos-arm64`, `windows-x64`, `darwin-x64`, `darwin-arm64`, `linux-x64-musl`, `linux-arm64-musl`.
+- `target`: The target platform for the binary (default to your current platform). Available targets: `linux-x64`, `linux-x64-baseline`, `macos-arm64`, `windows-x64`, `windows-x64-baseline`, `darwin-x64`, `darwin-arm64`, `linux-x64-musl`, `linux-arm64-musl`.
 - `volume`: The volume mount point for the binary (no volume mount by default). Useful for persistent storage for self-hosting, usually `/data`.
 
 ## Environment variables

--- a/packages/sveltekit/package-lock.json
+++ b/packages/sveltekit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jesterkit-sveltekit",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jesterkit-sveltekit",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "devDependencies": {
         "@sveltejs/kit": "^2.22.2",

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -5,7 +5,7 @@
     "build": "bun build.ts"
   },
   "module": "dist/index.js",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "EXE is an adapter for SvelteKit to build a standalone executable with full stack features such as SSR, API routes, server hooks....",
   "author": "Hugo Duprez",
   "license": "MIT",

--- a/packages/sveltekit/src/constants/const.ts
+++ b/packages/sveltekit/src/constants/const.ts
@@ -8,6 +8,7 @@ export const TARGETS_MAP: Record<NonNullable<AdapterOptions["target"]>, string> 
 	"linux-x64-baseline": "bun-linux-x64-baseline",
 	"macos-arm64": "bun-macos-arm64",
 	"windows-x64": "bun-windows-x64",
+	"windows-x64-baseline": "bun-windows-x64-baseline",
 	"darwin-x64": "bun-darwin-x64",
 	"darwin-arm64": "bun-darwin-arm64",
 	"linux-x64-musl": "bun-linux-x64-musl",

--- a/packages/sveltekit/src/types/AdapterOptions.d.ts
+++ b/packages/sveltekit/src/types/AdapterOptions.d.ts
@@ -3,6 +3,7 @@ type Target =
 	| "linux-x64-baseline"
 	| "macos-arm64"
 	| "windows-x64"
+	| "windows-x64-baseline"
 	| "darwin-x64"
 	| "darwin-arm64"
 	| "linux-x64-musl"

--- a/packages/tanstack/README.md
+++ b/packages/tanstack/README.md
@@ -38,7 +38,7 @@ Run the executable.
 
 - `out`: The output directory for the built binary (default: `dist`).
 - `binaryName`: The name of the executable (default: `app`).
-- `target`: The target platform for the binary (default to your current platform). Available targets: `linux-x64`, `macos-arm64`, `windows-x64`, `darwin-x64`, `darwin-arm64`, `linux-x64-musl`, `linux-arm64-musl`.
+- `target`: The target platform for the binary (default to your current platform). Available targets: `linux-x64`, `linux-x64-baseline`, `macos-arm64`, `windows-x64`, `windows-x64-baseline`, `darwin-x64`, `darwin-arm64`, `linux-x64-musl`, `linux-arm64-musl`.
 - `volume`: The volume mount point for the binary (no volume mount by default). Useful for persistent storage for self-hosting, usually `/data`.
 - `external`: The external dependencies to exclude from bundling (comma-separated string or array).
 

--- a/packages/tanstack/package-lock.json
+++ b/packages/tanstack/package-lock.json
@@ -19,7 +19,7 @@
       "peerDependencies": {
         "typescript": "^5"
       },
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.8",
@@ -147,5 +147,5 @@
       "license": "MIT"
     }
   },
-  "version": "0.1.2"
+  "version": "0.1.3"
 }

--- a/packages/tanstack/package.json
+++ b/packages/tanstack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jesterkit/exe-tanstack",
   "module": "dist/index.ts",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "EXE is a tool for TanStack to build a standalone executable with full stack features such as SSR, API routes, server hooks....",
   "author": "Hugo Duprez",
   "license": "MIT",

--- a/packages/tanstack/src/constants/const.ts
+++ b/packages/tanstack/src/constants/const.ts
@@ -6,6 +6,7 @@ export const TARGETS_MAP: Record<NonNullable<CLIArgs["target"]>, string> = {
 	"linux-x64-baseline": "bun-linux-x64-baseline",
 	"macos-arm64": "bun-macos-arm64",
 	"windows-x64": "bun-windows-x64",
+	"windows-x64-baseline": "bun-windows-x64-baseline",
 	"darwin-x64": "bun-darwin-x64",
 	"darwin-arm64": "bun-darwin-arm64",
 	"linux-x64-musl": "bun-linux-x64-musl",

--- a/packages/tanstack/src/types/CLIArgs.d.ts
+++ b/packages/tanstack/src/types/CLIArgs.d.ts
@@ -3,6 +3,7 @@ type Target =
 	| "linux-x64-baseline"
 	| "macos-arm64"
 	| "windows-x64"
+	| "windows-x64-baseline"
 	| "darwin-x64"
 	| "darwin-arm64"
 	| "linux-x64-musl"

--- a/packages/tanstack/src/utils/validation.ts
+++ b/packages/tanstack/src/utils/validation.ts
@@ -2,8 +2,10 @@ import type { CLIArgs } from "../types/CLIArgs";
 
 export const VALID_TARGETS = [
 	"linux-x64",
+	"linux-x64-baseline",
 	"macos-arm64",
 	"windows-x64",
+	"windows-x64-baseline",
 	"darwin-x64",
 	"darwin-arm64",
 	"linux-x64-musl",


### PR DESCRIPTION
Hi, i also wrote this on reddit :).

This is amazing, i have successfully created bun exe from Sveltekit SSR frontend which worked before on nodejs (this is lifesaving not to have copy node_modules between dev machine and offline server!). Runs on windows x64 with nssm for now ok.

But there was a hard road bump - initially i though it will not work - compiled exe run on minipc windows crashed right away, couldn't run cmd/powershell window with app to check log, everything crashed, nssm logs were empty. Finally it turned out to be newer CPU on dev machine (ryzen 7950x3d) vs intel n100 and probably bun bundling some cpu instruction that was missing on intel, like maybe avx512 or avx2 (but n100 actually supports avx2), or maybe that N100 ran windows as VM -> maybe vm cut instructions even less.

Tried to bundle with bun-windows-x64-baseline but still same, had to compile directly on n100. Any idea if this is possible to resolve somehow without need to compile on target machine? Or maybe is there any issue that adding bun-windows-x64-baseline is not working as it should?