### PR TITLE
add configurable idleTimeout and fix Windows binary path detection

### DIFF
--- a/packages/sveltekit/bun.lock
+++ b/packages/sveltekit/bun.lock
@@ -3,9 +3,6 @@
   "workspaces": {
     "": {
       "name": "adapter-tapestry",
-      "dependencies": {
-        "adapter-exe": ".",
-      },
       "devDependencies": {
         "@sveltejs/kit": "^2.22.2",
         "@types/bun": "latest",
@@ -141,8 +138,6 @@
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
-    "adapter-exe": ["adapter-exe@file:", { "devDependencies": { "@sveltejs/kit": "^2.22.2", "@types/bun": "latest", "@types/node": "^24.0.10" }, "peerDependencies": { "typescript": "^5" } }],
-
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
@@ -218,9 +213,5 @@
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 
     "zimmerframe": ["zimmerframe@1.1.2", "", {}, "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w=="],
-
-    "adapter-exe/@types/bun": ["@types/bun@1.2.19", "", { "dependencies": { "bun-types": "1.2.19" } }, "sha512-d9ZCmrH3CJ2uYKXQIUuZ/pUnTqIvLDS0SK7pFmbx8ma+ziH/FRMoAq5bYpRG7y+w1gl+HgyNZbtqgMq4W4e2Lg=="],
-
-    "adapter-exe/@types/bun/bun-types": ["bun-types@1.2.19", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-uAOTaZSPuYsWIXRpj7o56Let0g/wjihKCkeRqUBhlLVM/Bt+Fj9xTo+LhC1OV1XDaGkz4hNC80et5xgy+9KTHQ=="],
   }
 }

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -131,4 +131,4 @@ const server = Bun.serve({
 	},
 });
 
-console.log(`đź’ż Listening on http://localhost:${server.port}`);
+console.log(`💿 Listening on http://localhost:${server.port}`);

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -1,4 +1,4 @@
-// Libs
+﻿// Libs
 import { file } from "bun";
 import path from "node:path";
 import { execPath } from "process";
@@ -107,6 +107,7 @@ process.on('SIGINT', gracefulShutdown);
 const server = Bun.serve({
 	port: process.env.PORT ? parseInt(process.env.PORT) : 3000,
 	hostname: "0.0.0.0",
+	idleTimeout: process.env.BUN_IDLE_TIMEOUT ? parseInt(process.env.BUN_IDLE_TIMEOUT) : 255,
 	async fetch(req: Request, bunServer: Bun.Server) {
 		// Handle static assets
 		const staticResponse = await staticServer.respond(req);
@@ -130,4 +131,4 @@ const server = Bun.serve({
 	},
 });
 
-console.log(`💿 Listening on http://localhost:${server.port}`);
+console.log(`đź’ż Listening on http://localhost:${server.port}`);

--- a/packages/sveltekit/src/utils/compile.ts
+++ b/packages/sveltekit/src/utils/compile.ts
@@ -53,7 +53,9 @@ export async function compileApplication(
 	].join(" ");
 	execSync(`bun ${compileArgs}`, { stdio: "inherit" });
 
-	const binaryPath = join(options.out, options.binaryName);
+	// On Windows, Bun adds .exe extension automatically
+        const isWindows = process.platform === "win32";
+        const binaryPath = join(options.out, options.binaryName + (isWindows ? ".exe" : ""));
 	const { size: sizeInBytes } = await stat(binaryPath);
 	const sizeInMb = (sizeInBytes / (1024 * 1024)).toFixed(1);
 


### PR DESCRIPTION
This PR addresses two issues:

1. **Configurable idleTimeout for Bun.serve (server/index.ts)**
   - Added \idleTimeout\ option to \Bun.serve()\ with a default of 255 seconds
   - Configurable via \BUN_IDLE_TIMEOUT\ environment variable
   - Fixes timeout issues when using reverse proxies like IIS ARR, nginx, or Caddy
   - The default Bun timeout of 10 seconds is too short for SSR applications
     that need to fetch data from slow backends during page load

2. **Windows .exe extension handling (utils/compile.ts)**
   - On Windows, Bun automatically appends \.exe\ to compiled binaries
   - The \stat()\ call was failing because it didn't account for this extension
   - Added platform detection to correctly locate the compiled binary

Both fixes are backward compatible and don't require any changes to existing projects.
