### PR TITLE
feat: support additional bun compile args and --bytecode compatibility

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -41,6 +41,7 @@ Run the executable.
 - `target`: The target platform for the binary (default to your current platform). Available targets: `linux-x64`, `linux-x64-baseline`, `macos-arm64`, `windows-x64`, `windows-x64-baseline`, `darwin-x64`, `darwin-arm64`, `linux-x64-musl`, `linux-arm64-musl`.
 - `volume`: The volume mount point for the binary (no volume mount by default). Useful for persistent storage for self-hosting, usually `/data`.
 - `external`: The external dependencies to exclude from bundling (comma-separated string or array).
+- `bunArgs`: Additional arguments to pass to `bun build --compile` (e.g. `--minify --sourcemap`).
 
 Example
 

--- a/packages/nuxt/src/types/CLIArgs.d.ts
+++ b/packages/nuxt/src/types/CLIArgs.d.ts
@@ -20,4 +20,6 @@ export declare type CLIArgs = {
 	volume?: string;
 	/** External dependencies to exclude from bundling (comma-separated string or array) */
 	external?: string | string[];
+	/** Additional arguments to pass to bun build --compile (e.g. ["--minify", "--sourcemap"]) */
+	bunArgs?: string[];
 };

--- a/packages/nuxt/src/utils/compile.ts
+++ b/packages/nuxt/src/utils/compile.ts
@@ -46,6 +46,7 @@ export async function compileApplication(options: CLIArgs) {
 		"build",
 		"--compile",
 		...(options.target ? [`--target=${TARGETS_MAP[options.target]}`] : []),
+		...(options.bunArgs || []),
 		".output/bundle.js",
 		"--outfile",
 		join(out, binaryName),

--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -42,6 +42,7 @@ Run the executable
 - `embedStatic`: Whether to embed static assets in the binary (default: `true`).
 - `target`: The target platform for the binary (default to your current platform). Available targets: `linux-x64`, `linux-x64-baseline`, `macos-arm64`, `windows-x64`, `windows-x64-baseline`, `darwin-x64`, `darwin-arm64`, `linux-x64-musl`, `linux-arm64-musl`.
 - `volume`: The volume mount point for the binary (no volume mount by default). Useful for persistent storage for self-hosting, usually `/data`.
+- `bunArgs`: Additional arguments to pass to `bun build --compile` (e.g. `["--minify", "--sourcemap", "--bytecode"]`).
 
 ## Environment variables
 

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -1,4 +1,4 @@
-﻿// Libs
+// Libs
 import { file } from "bun";
 import path from "node:path";
 import { execPath } from "process";
@@ -10,125 +10,126 @@ import { assetMap } from "./assets.generated.ts";
 import type { Server as ServerType } from "@sveltejs/kit";
 import type { SSRManifest } from "@sveltejs/kit";
 
-// Variables
-const manifest = await getSvelteKitManifest();
-const prerenderedRoutes = await getPrerenderedRoutes(manifest);
-const svelteKitServer = await instantiateServer(manifest);
-const staticServer = {
-	respond: async (req: Request) => {
-		const url = new URL(req.url);
-		const headers = new Headers({
-			"Cache-Control": "max-age=0, must-revalidate",
-		});
+// Bootstrap the server inside an async IIFE to avoid top-level await,
+// which is not supported by bun build --compile --bytecode.
+(async () => {
+	async function getSvelteKitManifest() {
+		// @ts-ignore
+		const manifestModule = await import("../manifest.js");
+		const manifest = manifestModule.default;
+		return manifest as SSRManifest;
+	}
 
-		if (prerenderedRoutes.includes(url.pathname)) {
-			const htmlPath = url.pathname === "/" ? "/index.html" : `${url.pathname}.html`;
-			const htmlFile = await getFile(htmlPath);
-			if (htmlFile) {
-				headers.set("Content-Type", htmlFile.type || "application/octet-stream");
-				return new Response(htmlFile, {
+	async function getPrerenderedRoutes(manifest: SSRManifest) {
+		return Array.from(manifest._.prerendered_routes);
+	}
+
+	async function instantiateServer(manifest: SSRManifest) {
+		const serverModule = await import("../server/index.js");
+		const { Server } = serverModule as { Server: new (manifest: SSRManifest) => ServerType };
+
+		const server = new Server(manifest);
+		await server.init({ env: Bun.env as Record<string, string> });
+
+		return server;
+	}
+
+	async function getFile(pathname: string) {
+		let decodedPathname: string;
+		try {
+			decodedPathname = decodeURIComponent(pathname);
+			if (decodedPathname.includes("../") || decodedPathname.includes("..\\")) return null;
+		} catch (error) {
+			decodedPathname = pathname;
+		}
+
+		if (assetMap.has(decodedPathname)) return file(assetMap.get(decodedPathname));
+
+		const binaryDir = path.dirname(execPath);
+		const staticBuildDirs = ["client", "prerendered"];
+
+		for (const dir of staticBuildDirs) {
+			const externalFile = file(path.join(binaryDir, dir, decodedPathname));
+			if (await externalFile.exists()) return externalFile;
+		}
+	}
+
+	const manifest = await getSvelteKitManifest();
+	const prerenderedRoutes = await getPrerenderedRoutes(manifest);
+	const svelteKitServer = await instantiateServer(manifest);
+	const staticServer = {
+		respond: async (req: Request) => {
+			const url = new URL(req.url);
+			const headers = new Headers({
+				"Cache-Control": "max-age=0, must-revalidate",
+			});
+
+			if (prerenderedRoutes.includes(url.pathname)) {
+				const htmlPath = url.pathname === "/" ? "/index.html" : `${url.pathname}.html`;
+				const htmlFile = await getFile(htmlPath);
+				if (htmlFile) {
+					headers.set("Content-Type", htmlFile.type || "application/octet-stream");
+					return new Response(htmlFile, {
+						headers,
+					});
+				}
+			}
+
+			const assetFile = await getFile(url.pathname);
+			if (assetFile) {
+				if (url.pathname.startsWith(`/${manifest.appDir}/immutable/`))
+					headers.set("Cache-Control", "public, max-age=31536000, immutable");
+				headers.set("Content-Type", assetFile.type || "application/octet-stream");
+				return new Response(assetFile, {
 					headers,
 				});
 			}
-		}
 
-		const assetFile = await getFile(url.pathname);
-		if (assetFile) {
-			if (url.pathname.startsWith(`/${manifest.appDir}/immutable/`))
-				headers.set("Cache-Control", "public, max-age=31536000, immutable");
-			headers.set("Content-Type", assetFile.type || "application/octet-stream");
-			return new Response(assetFile, {
-				headers,
+			return null;
+		},
+	};
+
+	const server = Bun.serve({
+		port: process.env.PORT ? parseInt(process.env.PORT) : 3000,
+		hostname: "0.0.0.0",
+		idleTimeout: process.env.BUN_IDLE_TIMEOUT ? parseInt(process.env.BUN_IDLE_TIMEOUT) : 255,
+		async fetch(req: Request, bunServer: Bun.Server) {
+			const staticResponse = await staticServer.respond(req);
+			if (staticResponse) return staticResponse;
+
+			return await svelteKitServer.respond(req, {
+				getClientAddress() {
+					return bunServer.requestIP(req)?.address || "127.0.0.1";
+				},
 			});
-		}
+		},
+		error(e: Error) {
+			return Response.json(
+				{
+					code: 500,
+					message: "Something went wrong",
+				},
+				{ status: 500 }
+			);
+		},
+	});
 
-		return null;
-	},
-};
+	console.log(`Listening on http://localhost:${server.port}`);
 
-async function getSvelteKitManifest() {
-	// @ts-ignore
-	const manifestModule = await import("../manifest.js");
-	const manifest = manifestModule.default;
-	return manifest as SSRManifest;
-}
+	let shuttingDown = false;
+	async function gracefulShutdown(reason: 'SIGINT' | 'SIGTERM') {
+		if (shuttingDown) return;
+		shuttingDown = true;
+		console.info('Stopping server...');
+		// @ts-expect-error custom events cannot be typed
+		process.emit('sveltekit:shutdown', reason);
+		await server.stop(true);
+		console.info('Stopped server');
 
-async function getPrerenderedRoutes(manifest: SSRManifest) {
-	return Array.from(manifest._.prerendered_routes);
-}
-
-async function instantiateServer(manifest: SSRManifest) {
-	const serverModule = await import("../server/index.js");
-	const { Server } = serverModule as { Server: new (manifest: SSRManifest) => ServerType };
-
-	const server = new Server(manifest);
-	await server.init({ env: Bun.env as Record<string, string> });
-
-	return server;
-}
-
-async function getFile(pathname: string) {
-	let decodedPathname: string;
-	try {
-		decodedPathname = decodeURIComponent(pathname);
-		// Prevent path traversal
-		if (decodedPathname.includes("../") || decodedPathname.includes("..\\")) return null;
-	} catch (error) {
-		decodedPathname = pathname;
+		process.removeListener('SIGINT', gracefulShutdown);
+		process.removeListener('SIGTERM', gracefulShutdown);
 	}
 
-	// Search in embedded assetMap
-	if (assetMap.has(decodedPathname)) return file(assetMap.get(decodedPathname));
-
-	// Search on disk
-	const binaryDir = path.dirname(execPath);
-	const staticBuildDirs = ["client", "prerendered"];
-
-	for (const dir of staticBuildDirs) {
-		const externalFile = file(path.join(binaryDir, dir, decodedPathname));
-		if (await externalFile.exists()) return externalFile;
-	}
-}
-
-async function gracefulShutdown(reason: 'SIGINT' | 'SIGTERM') {
-	console.info('Stopping server...');
-	// @ts-expect-error custom events cannot be typed
-	process.emit('sveltekit:shutdown', reason);
-	await server.stop(true);
-	console.info('Stopped server');
-
-	process.removeListener('SIGINT', gracefulShutdown);
-	process.removeListener('SIGTERM', gracefulShutdown);
-}
-
-process.on('SIGTERM', gracefulShutdown);
-process.on('SIGINT', gracefulShutdown);
-
-const server = Bun.serve({
-	port: process.env.PORT ? parseInt(process.env.PORT) : 3000,
-	hostname: "0.0.0.0",
-	idleTimeout: process.env.BUN_IDLE_TIMEOUT ? parseInt(process.env.BUN_IDLE_TIMEOUT) : 255,
-	async fetch(req: Request, bunServer: Bun.Server) {
-		// Handle static assets
-		const staticResponse = await staticServer.respond(req);
-		if (staticResponse) return staticResponse;
-
-		// Handle other routes (SSR, API endpoints, etc.)
-		return await svelteKitServer.respond(req, {
-			getClientAddress() {
-				return bunServer.requestIP(req)?.address || "127.0.0.1";
-			},
-		});
-	},
-	error(e: Error) {
-		return Response.json(
-			{
-				code: 500,
-				message: "Something went wrong",
-			},
-			{ status: 500 }
-		);
-	},
-});
-
-console.log(`💿 Listening on http://localhost:${server.port}`);
+	process.on('SIGTERM', gracefulShutdown);
+	process.on('SIGINT', gracefulShutdown);
+})();

--- a/packages/sveltekit/src/types/AdapterOptions.d.ts
+++ b/packages/sveltekit/src/types/AdapterOptions.d.ts
@@ -20,4 +20,6 @@ export declare type AdapterOptions = {
 	target?: Target;
 	/** Volume mount point for the binary (default no volume mount). Can be used for persistent storage, usually /data. */
 	volume?: string;
+	/** Additional arguments to pass to bun build --compile (e.g. ["--minify", "--sourcemap"]) */
+	bunArgs?: string[];
 };

--- a/packages/sveltekit/src/utils/compile.ts
+++ b/packages/sveltekit/src/utils/compile.ts
@@ -12,7 +12,7 @@ import { SVELTEKIT_DIR, TARGETS_MAP } from "../constants/const";
 
 export async function compileApplication(
 	builder: Builder,
-	options: { target?: Target; out: string; binaryName: string }
+	options: { target?: Target; out: string; binaryName: string; bunArgs?: string[] }
 ) {
 	try {
 		const bunVersion = execSync("bun --version", { encoding: "utf8", stdio: "pipe" }).trim();
@@ -47,6 +47,7 @@ export async function compileApplication(
 		"build",
 		"--compile",
 		...(options.target ? [`--target=${TARGETS_MAP[options.target]}`] : []),
+		...(options.bunArgs || []),
 		join(SVELTEKIT_DIR, "temp-server/index.ts"),
 		"--outfile",
 		join(options.out, options.binaryName),

--- a/packages/tanstack/README.md
+++ b/packages/tanstack/README.md
@@ -41,6 +41,7 @@ Run the executable.
 - `target`: The target platform for the binary (default to your current platform). Available targets: `linux-x64`, `linux-x64-baseline`, `macos-arm64`, `windows-x64`, `windows-x64-baseline`, `darwin-x64`, `darwin-arm64`, `linux-x64-musl`, `linux-arm64-musl`.
 - `volume`: The volume mount point for the binary (no volume mount by default). Useful for persistent storage for self-hosting, usually `/data`.
 - `external`: The external dependencies to exclude from bundling (comma-separated string or array).
+- `bunArgs`: Additional arguments to pass to `bun build --compile` (e.g. `--minify --sourcemap`).
 
 Example
 

--- a/packages/tanstack/src/types/CLIArgs.d.ts
+++ b/packages/tanstack/src/types/CLIArgs.d.ts
@@ -20,4 +20,6 @@ export declare type CLIArgs = {
 	volume?: string;
 	/** External dependencies to exclude from bundling (comma-separated string or array) */
 	external?: string | string[];
+	/** Additional arguments to pass to bun build --compile (e.g. ["--minify", "--sourcemap"]) */
+	bunArgs?: string[];
 };

--- a/packages/tanstack/src/utils/compile.ts
+++ b/packages/tanstack/src/utils/compile.ts
@@ -46,6 +46,7 @@ export async function compileApplication(options: CLIArgs) {
 		"build",
 		"--compile",
 		...(options.target ? [`--target=${TARGETS_MAP[options.target]}`] : []),
+		...(options.bunArgs || []),
 		".output/bundle.js",
 		"--outfile",
 		join(out, binaryName),


### PR DESCRIPTION
Closes #18

## Summary

- **All packages (sveltekit, nuxt, tanstack):** Add a `bunArgs` option for passing extra flags to `bun build --compile` (e.g. `--minify`, `--sourcemap`, `--bytecode`)
- **sveltekit:** Wrap server entry in async IIFE to eliminate top-level `await`, required for `--bytecode` support
- **sveltekit:** Fix duplicate shutdown logs by adding a guard to `gracefulShutdown`

## Usage

```js
// svelte.config.js
adapter({
  bunArgs: ["--minify", "--sourcemap", "--bytecode"]
})
```

## Test plan

- [x] Built sveltekit app with `bunArgs: ["--minify", "--sourcemap", "--bytecode"]` — compiles successfully
- [x] Verified binary starts and serves static assets correctly
- [x] Verified `Ctrl+C` prints shutdown message only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)